### PR TITLE
Fix #11, wrong script used in YorkUrbanDB install script

### DIFF
--- a/datasets/install_york_dataset.bash
+++ b/datasets/install_york_dataset.bash
@@ -7,5 +7,5 @@ unzip YorkUrbanDB.zip
 # http://unix.stackexchange.com/questions/77077/how-do-i-use-pushd-and-popd-commands/77081#77081
 pushd ..
 ./install_dataset.bash public/image datasets/YorkUrbanDB
-node ./createImageSet.js datasets/YorkUrbanDB.json YorkUrbanDB
+node ./create_image_set.js datasets/YorkUrbanDB.json YorkUrbanDB
 popd


### PR DESCRIPTION
Just fixing a dumb mistake. At some point I realized underscores are probably better for script names instead of CamelCase.
