### PR TITLE
Fix #18, made name field for image model unique.

### DIFF
--- a/install_dataset.bash
+++ b/install_dataset.bash
@@ -42,6 +42,6 @@ echo -e "\n]" >> $FOLDER.json
 # http://docs.mongodb.org/manual/reference/program/mongoimport/#cmdoption--upsert
 echo ""
 echo "Images saved to $FOLDER.json, importing into local mongodb..."
-echo "  mongoimport -d annotator -c images --upsert --upsertFields sha --type json --jsonArray --file $FOLDER.json"
+echo "  mongoimport -d annotator -c images --upsert --upsertFields name --type json --jsonArray --file $FOLDER.json"
 echo ""
-mongoimport -d annotator -c images --upsert --upsertFields sha --type json --jsonArray --file $FOLDER.json
+mongoimport -d annotator -c images --upsert --upsertFields name --type json --jsonArray --file $FOLDER.json

--- a/models/image.js
+++ b/models/image.js
@@ -4,7 +4,7 @@ var Schema = mongoose.Schema;
 
 var imageSchema = new Schema({
   sha: {type: String, required: true, index: true},
-  name: {type: String, required: true, index: true},
+  name: {type: String, required: true, index: true, unique: true},
   filename: {type: String, required: true},
   url: {type: String, required: true},
   width: {type: Number, required: true},


### PR DESCRIPTION
Turns out the problem was really stupid. I was upserting based on the SHA1 hash so if the SHA1 hash matched it simply updated the existing entry thus preventing duplicate SHA1 hashes. For good measure I also made the name field unique for images.

At first I though the problem was that indexed fields had to be unique by default. I thought the way to solve that was to not index the `sha` field and instead create a compound index with `sha` and `name`. Eventually I spotted the upsert problem and learned that indexed fields can in fact be duplicate.
